### PR TITLE
Fixed dispose socket in client after got error

### DIFF
--- a/Beanstalk.Client/BeanstalkClient.cs
+++ b/Beanstalk.Client/BeanstalkClient.cs
@@ -296,7 +296,9 @@ namespace Droog.Beanstalk.Client {
             if(suppressFinalizer) {
                 GC.SuppressFinalize(this);
             }
-            _socket.Dispose();
+	    if (_socket != null) {
+                _socket.Dispose();
+	    }
             _disposed = true;
         }
 


### PR DESCRIPTION
Usualy, if got error after connection reset exception, _socket variadble allready disposed and we need check on not null in dispose client.
